### PR TITLE
Update Job.php

### DIFF
--- a/src/Command/Job.php
+++ b/src/Command/Job.php
@@ -870,6 +870,8 @@ class Job extends Command
                 $_ENV['email_queue']
             );
             $user->class = 0;
+            $user->node_connector = Config::getconfig('Register.string.defaultConn');
+            $user->node_speedlimit = Config::getconfig('Register.string.defaultSpeedlimit');
             $user->save();
         }
     }


### PR DESCRIPTION
fix：当订阅等级过期时并不会重置设备限制和速率限制为默认值