### PR TITLE
fix: No UUID when creating an admin account

### DIFF
--- a/src/Command/User.php
+++ b/src/Command/User.php
@@ -9,6 +9,7 @@ use App\Utils\GA;
 use App\Utils\Hash;
 use App\Utils\Tools;
 use Exception;
+use Ramsey\Uuid\Uuid;
 
 class User extends Command
 {
@@ -148,10 +149,12 @@ class User extends Command
             echo 'start create admin account';
             // create admin user
             // do reg user
+            $current_timestamp      = time();
             $user                   = new ModelsUser();
-            $user->user_name        = 'admin';
+            $user->user_name        = 'SupeiAdmin';
             $user->email            = $email;
             $user->pass             = Hash::passwordHash($passwd);
+            $user->uuid             = Uuid::uuid3(Uuid::NAMESPACE_DNS, $email . '|' . $current_timestamp);
             $user->passwd           = Tools::genRandomChar(16);
             $user->port             = Tools::getLastPort() + 1;
             $user->t                = 0;


### PR DESCRIPTION
fix: No UUID when creating an admin account