### PR TITLE
解决file_get_contents()报错

### DIFF
--- a/src/Command/Job.php
+++ b/src/Command/Job.php
@@ -198,8 +198,14 @@ class Job extends Command
             }
         }
         echo '重置用户流量成功;' . PHP_EOL;
-
-        $qqwry = file_get_contents('http://qqwry.mirror.noc.one/QQWry.Dat?from=sspanel_uim');
+        
+        $stream_opts = [
+            "ssl" => [
+                "verify_peer"=>false,
+                "verify_peer_name"=>false,
+            ]
+        ];
+        $qqwry = file_get_contents('http://qqwry.mirror.noc.one/QQWry.Dat?from=sspanel_uim', false, stream_context_create($stream_opts));
         if ($qqwry != '') {
             rename(BASE_PATH . '/storage/qqwry.dat', BASE_PATH . '/storage/qqwry.dat.bak');
             $fp = fopen(BASE_PATH . '/storage/qqwry.dat', 'wb');


### PR DESCRIPTION
解决由于高php版本问题出现的 file_get_contents(): SSL operation failed with code 1 报错。