### PR TITLE
fix: 更换 QQWry 纯真 IP 镜像地址

### DIFF
--- a/src/Command/Job.php
+++ b/src/Command/Job.php
@@ -205,7 +205,7 @@ class Job extends Command
                 "verify_peer_name"=>false,
             ]
         ];
-        $qqwry = file_get_contents('http://qqwry.mirror.noc.one/QQWry.Dat?from=sspanel_uim', false, stream_context_create($stream_opts));
+        $qqwry = file_get_contents('https://qqwry-mirror.cdn.skk.moe/QQWry.Dat?from=sspanel_uim', false, stream_context_create($stream_opts));
         if ($qqwry != '') {
             rename(BASE_PATH . '/storage/qqwry.dat', BASE_PATH . '/storage/qqwry.dat.bak');
             $fp = fopen(BASE_PATH . '/storage/qqwry.dat', 'wb');

--- a/src/Command/Tool.php
+++ b/src/Command/Tool.php
@@ -72,7 +72,7 @@ class Tool extends Command
     public function initQQWry()
     {
         echo ('开始下载纯真 IP 数据库....');
-        $qqwry = file_get_contents('https://raw.githubusercontent.com/out0fmemory/qqwry.dat/master/qqwry_lastest.dat');
+        $qqwry = file_get_contents('https://qqwry-mirror.cdn.skk.moe/QQWry.Dat?from=sspanel_uim');
         if ($qqwry != '') {
             $fp = fopen(BASE_PATH . '/storage/qqwry.dat', 'wb');
             if ($fp) {
@@ -83,7 +83,7 @@ class Tool extends Command
                 echo ('纯真 IP 数据库保存失败！');
             }
         } else {
-            echo ('下载失败！请重试，或在 https://github.com/SukkaW/qqwry-mirror/issues/new 反馈！');
+            echo ('下载失败！请重试，或在 https://github.com/SukkaLab/lab.skk.moe/issues/new 反馈！');
         }
     }
 


### PR DESCRIPTION
`qqwry.mirror.noc.one` 将于 2025.11.31 UTC+0 起被弃用，更换到替换域名。